### PR TITLE
display pending reason in report

### DIFF
--- a/src/Jasmine2AllureReporter.js
+++ b/src/Jasmine2AllureReporter.js
@@ -54,7 +54,7 @@ function Jasmine2AllureReporter(userDefinedConfig, allureReporter) {
       };
     } else if (result.status === 'pending') {
       return {
-        message: 'This test has not been implemented yet',
+        message: result.pendingReason,
         stack: ''
       };
     }


### PR DESCRIPTION
We often use `it(/*...*/).pend(<reason>)` instead of `xit` to make test pending and want to see pending reason in generated report instead of hardcoded message. By default if no reason is given (xit was used) jasmine adds "Temporarily disabled with xit" message.