### PR TITLE
Upd matcher - rename var allure <> global.allure

### DIFF
--- a/src/Jasmine2AllureReporter.js
+++ b/src/Jasmine2AllureReporter.js
@@ -1,6 +1,6 @@
 var Allure = require('allure-js-commons');
 var path = require('path');
-var allure = new Allure();
+var jasmine2Allure = new Allure();
 
 /**
  *
@@ -11,7 +11,7 @@ var allure = new Allure();
  */
 function Jasmine2AllureReporter(userDefinedConfig, allureReporter) {
   var Status = {PASSED: 'passed', FAILED: 'failed', BROKEN: 'broken', PENDING: 'pending'};
-  this.allure = allureReporter || allure;
+  this.jasmine2Allure = allureReporter || jasmine2Allure;
 
   this.configure = function(userDefinedConfig) {
     var pluginConfig = {};
@@ -19,23 +19,23 @@ function Jasmine2AllureReporter(userDefinedConfig, allureReporter) {
     pluginConfig.resultsDir = userDefinedConfig.resultsDir || 'allure-results';
     pluginConfig.basePath = userDefinedConfig.basePath || '.';
     var outDir = path.resolve(pluginConfig.basePath, pluginConfig.resultsDir);
-    this.allure.setOptions({targetDir: outDir});
+    this.jasmine2Allure.setOptions({targetDir: outDir});
   };
   this.configure(userDefinedConfig);
 
   this.suiteStarted = function(suite) {
-    this.allure.startSuite(suite.fullName);
+    this.jasmine2Allure.startSuite(suite.fullName);
   };
   this.suiteDone = function() {
-    this.allure.endSuite();
+    this.jasmine2Allure.endSuite();
   };
   this.specStarted = function(spec) {
-    this.allure.startCase(spec.description);
+    this.jasmine2Allure.startCase(spec.description);
   };
   this.specDone = function(spec) {
     var status = this._getTestcaseStatus(spec.status);
     var errorInfo = this._getTestcaseError(spec);
-    this.allure.endCase(status, errorInfo);
+    this.jasmine2Allure.endCase(status, errorInfo);
   };
   this._getTestcaseStatus = function(status) {
     if (status === 'disabled' || status === 'pending') {
@@ -69,7 +69,7 @@ function Jasmine2AllureReporter(userDefinedConfig, allureReporter) {
 
 }
 
-exports.allureReporter = allure;
+exports.allureReporter = jasmine2Allure;
 /**
  * Usually it's preferred to use {@code module.exports.singleton}, but if for some reason you need a brand new instance
  * of the reporter, give it a shot.


### PR DESCRIPTION
In index.js there is "global.allure = new Runtime(allureReporter);".
using var "allure" in the matcher blocks from simple report-extensions, like adding "allure.epic('something')" inside specDone(), even though such individual extensions can be highly valuable.
In my case, epic was set in "beforeEach", but pending test cases (xit) didn't execute beforeEach and didn't get the epic.